### PR TITLE
Reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python
+FROM python:alpine
 
 WORKDIR /app
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN wget -O - https://sh.rustup.rs -q | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 COPY requirements.txt /app
 


### PR DESCRIPTION
#18

I'm not familiar with python production environment, so I have just used alpine image.
Now image is 1.39GB instead of 2.14GB, but I think someone with python experience can reduce it's dependencies size.